### PR TITLE
復元時に時間を取得できるようにする

### DIFF
--- a/src/android/CDVRecorder.java
+++ b/src/android/CDVRecorder.java
@@ -13,7 +13,9 @@ import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioRecord;
 import android.media.MediaCodec;
+import android.media.MediaMetadataRetriever;
 import android.media.MediaRecorder;
+import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 import android.view.animation.AccelerateInterpolator;
@@ -467,16 +469,23 @@ public class CDVRecorder extends CordovaPlugin {
     }
 
 
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private void getAudio(final Activity activity, final CallbackContext callbackContext, final String audioId) {
-        File inputFile = new File(RECORDING_ROOT_DIR + "/" + audioId + "/merged/merged.wav");
+        String pathname = RECORDING_ROOT_DIR + "/" + audioId + "/merged/merged.wav";
+        File inputFile = new File(pathname);
 
         JSONObject audioData = new JSONObject();
         JSONObject fullAudio = new JSONObject();
 
         try {
             fullAudio.put("path", "file://" + inputFile.getAbsoluteFile());
-            audioData.put("full_audio", fullAudio);
+            Uri uri = Uri.parse(pathname);
+            MediaMetadataRetriever mmr = new MediaMetadataRetriever();
+            mmr.setDataSource(this.cordova.getContext(), uri);
+            String durationStr = mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
 
+            fullAudio.put("duration", Integer.parseInt(durationStr) / 1000.0);
+            audioData.put("full_audio", fullAudio);
             callbackContext.success(audioData);
 
         } catch (Exception e) {

--- a/src/ios/CDVRecorder.swift
+++ b/src/ios/CDVRecorder.swift
@@ -437,7 +437,7 @@ import Alamofire
             let audioPath = URL(fileURLWithPath: (recordingDir + "/\(folderID)/joined/\(j)"))
             let asset = AVURLAsset(url:audioPath)
             
-            let joinedAudio = Audio(name: "joined_audio", duration: String(asset.duration.value), path: audioPath.absoluteString)
+            let joinedAudio = Audio(name: "joined_audio", duration: String(asset.duration.seconds), path: audioPath.absoluteString)
             
             let audio = RecordedAudio(audios: [], fullAudio: joinedAudio, folderID: folderID)
             
@@ -570,7 +570,7 @@ import Alamofire
                     
                     let asset = AVURLAsset(url: joined_folder);
                     
-                    exportAudio = Audio(name:"joined_audio", duration: String(asset.duration.value), path: joined_folder.absoluteString)
+                    exportAudio = Audio(name:"joined_audio", duration: String(asset.duration.seconds), path: joined_folder.absoluteString)
                     
                     semaphore.signal()
                 case .failed, .cancelled:
@@ -639,7 +639,7 @@ import Alamofire
                 switch (session.status) {
                 case .completed:
                     print("[completed -------------------------->]")
-                    audio = Audio(name: "joined_audio", duration: String(asset.duration.value), path: outputPath.absoluteString )
+                    audio = Audio(name: "joined_audio", duration: String(asset.duration.seconds), path: outputPath.absoluteString )
                     semaphore.signal()
                     break
                 case .failed:
@@ -857,7 +857,7 @@ import Alamofire
         let folderPath = getCurrentFolderPath().absoluteString
         let fullAudioPath = folderPath + "queue/\(currentAudioName!).wav"
         let asset = AVURLAsset(url: URL(string: fullAudioPath)!)
-        let data = Audio(name: currentAudioName!, duration: String(asset.duration.value), path: fullAudioPath)
+        let data = Audio(name: currentAudioName!, duration: String(asset.duration.seconds), path: fullAudioPath)
         queue.append(data)
         
         // 追加が終わったら true
@@ -990,7 +990,7 @@ import Alamofire
                     
                     let asset = AVURLAsset(url: joinedFolder);
                     
-                    result = Audio(name:"joined_audio", duration: String(asset.duration.value), path: joinedFolder.absoluteString)
+                    result = Audio(name:"joined_audio", duration: String(asset.duration.seconds), path: joinedFolder.absoluteString)
                     
                     semaphore.signal()
                 case .failed, .cancelled:


### PR DESCRIPTION
コラボ時はsplitで時間を設定しているのでネイティブから取得できなくても問題なし
未録音時に復元した際に時間がおかしくなるため、セットできるようにしました